### PR TITLE
uyghur2dict.py: Declare python encoding

### DIFF
--- a/dict/src/lib/full_text_trans.cpp
+++ b/dict/src/lib/full_text_trans.cpp
@@ -501,7 +501,7 @@ void FullTextTrans::build_request(
 	if(engine_index==TranslateEngine_Google){
 		httpMethod = HTTP_METHOD_GET;
 		host = "translate.google.com";
-		file = "/translate_t?ie=UTF-8";
+		file = "/#";
 		allow_absolute_URI = true;
 	} else if(engine_index==TranslateEngine_Yahoo){
 		httpMethod = HTTP_METHOD_POST;
@@ -525,9 +525,8 @@ void FullTextTrans::build_request(
 	} */
 
 	if(engine_index==TranslateEngine_Google) {
-		file += "&sl=";
 		file += engines[engine_index].srclangs[fromlang_index].code;
-		file += "&tl=";
+		file += "/";
 		const size_t tolangind = engines[engine_index].srclangs[fromlang_index].tolangind;
 		file += engines[engine_index].tgtlangs[tolangind][tolang_index].code;
 	} else if(engine_index==TranslateEngine_Yahoo || engine_index==TranslateEngine_ExciteJapan) {
@@ -564,7 +563,7 @@ void FullTextTrans::build_request(
 		}
 	}
 	if (engine_index == TranslateEngine_Google) {
-		file += "&text=";
+		file += "/";
 		file += text;
 	} else if(engine_index == TranslateEngine_Yahoo) {
 		body += "&trtext=";
@@ -685,7 +684,7 @@ void FullTextTrans::parse_response(const char* buffer, size_t buffer_len, glong 
 			}
 		}
 	} else if (engine_index == TranslateEngine_Google) {
-		static const char * const GoogleTranslateStartMark = "<span id=result_box ";
+		static const char * const GoogleTranslateStartMark = "<span id=\"result_box\" ";
 		static const char * const GoogleTranslateEndMark = "</div>";
 
 		do {

--- a/tools/src/libtabfile.cpp
+++ b/tools/src/libtabfile.cpp
@@ -22,6 +22,7 @@
 #include <cstring>
 #include <cstdlib>
 #include <string>
+#include <sstream>
 #include <glib/gstdio.h>
 #include <glib.h>
 
@@ -228,9 +229,10 @@ static bool write_dictionary(const char *filename, GArray *array)
 	g_message("%s wordcount: %d.", get_impl(basefilename), array->len);
 
 #ifndef _WIN32
-	std::string command(std::string("dictzip ") + dicfilename);
+	std::stringstream command;
+	command << "dictzip \"" << dicfilename << "\"";
 	int result;
-	result = system(command.c_str());
+	result = system(command.str().c_str());
 	if (result == -1) {
 		g_print("system() error!\n");
 	}

--- a/tools/src/uyghur2dict.py
+++ b/tools/src/uyghur2dict.py
@@ -1,4 +1,5 @@
 ﻿#!/usr/bin/env python
+# -*- coding: utf-8 -*-
 #
 # uyghur2dict
 # By Abdisalam (anatilim@gmail.com), inspired by Michael Robinson's hanzim2dict converter.


### PR DESCRIPTION
Fix the following problem with (python-2.7):
$ stardict_uyghur2dict.py
  File "/usr/lib/python-exec/python2.7/stardict_uyghur2dict.py", line 80
SyntaxError: Non-ASCII character '\xe3' in file /usr/lib/python-exec/python2.7/stardict_uyghur2dict.py on line 80, but no encoding declared; see http://python.org/dev/peps/pep-0263/ for details