### PR TITLE
uyghur2dict.py: Declare python encoding

### DIFF
--- a/tools/src/uyghur2dict.py
+++ b/tools/src/uyghur2dict.py
@@ -1,4 +1,5 @@
 ﻿#!/usr/bin/env python
+# -*- coding: utf-8 -*-
 #
 # uyghur2dict
 # By Abdisalam (anatilim@gmail.com), inspired by Michael Robinson's hanzim2dict converter.


### PR DESCRIPTION
Fix the following problem:
$ stardict_uyghur2dict.py
  File "/usr/lib/python-exec/python2.7/stardict_uyghur2dict.py", line 80
SyntaxError: Non-ASCII character '\xe3' in file /usr/lib/python-exec/python2.7/stardict_uyghur2dict.py on line 80, but no encoding declared; see http://python.org/dev/peps/pep-0263/ for details