### PR TITLE
Fix typo in header guard

### DIFF
--- a/dict/src/pangoview.h
+++ b/dict/src/pangoview.h
@@ -18,7 +18,7 @@
  */
 
 #ifndef PANGOVIEW_H
-#define PAGNOVIEW_H
+#define PANGOVIEW_H
 
 #include <list>
 #include <string>


### PR DESCRIPTION
Fixes:
```
./pangoview.h:20:9: warning: 'PANGOVIEW_H' is used as a header guard here, followed by #define of a different macro [-Wheader-guard]
#ifndef PANGOVIEW_H
        ^~~~~~~~~~~
./pangoview.h:21:9: note: 'PAGNOVIEW_H' is defined here; did you mean 'PANGOVIEW_H'?
#define PAGNOVIEW_H
        ^~~~~~~~~~~
        PANGOVIEW_H
1 warning generated.
```