### PR TITLE
autogen.sh: On error, exit with an error code

### DIFF
--- a/autogen.sh
+++ b/autogen.sh
@@ -6,21 +6,21 @@ echo "Bootstrapping StarDict root..."
 # 	echo;
 # 	echo "You must have libtool installed to compile StarDict";
 # 	echo;
-# 	exit;
+# 	exit 1;
 # }
 
 (automake --version) < /dev/null > /dev/null 2>&1 || {
 	echo;
 	echo "You must have automake installed to compile StarDict";
 	echo;
-	exit;
+	exit 1;
 }
 
 (autoconf --version) < /dev/null > /dev/null 2>&1 || {
 	echo;
 	echo "You must have autoconf installed to compile StarDict";
 	echo;
-	exit;
+	exit 1;
 }
 
 echo "Generating configuration files for StarDict, please wait...."
@@ -40,13 +40,13 @@ aclocal -I m4 || exit;
 # echo "Running autoheader...."
 # autoheader || exit;
 echo "Running automake --add-missing --copy...."
-automake --add-missing --copy;
+automake --add-missing --copy || exit;
 echo "Running autoconf ...."
 autoconf || exit;
 echo "Running automake ...."
 automake || exit;
 cd "$topdir"
-${srcdir}/lib/autogen.sh
-${srcdir}/dict/autogen.sh
-${srcdir}/tools/autogen.sh
+${srcdir}/lib/autogen.sh || exit
+${srcdir}/dict/autogen.sh || exit
+${srcdir}/tools/autogen.sh || exit
 #"${srcdir}/configure" --prefix=/usr --sysconfdir=/etc --mandir=/usr/share/man --disable-deprecations --disable-dictdotcn --disable-gnome-support --disable-scrollkeeper "$@"

--- a/lib/autogen.sh
+++ b/lib/autogen.sh
@@ -6,21 +6,21 @@ echo "Boostrapping common lib..."
 	echo;
 	echo "You must have libtool installed to compile common lib";
 	echo;
-	exit;
+	exit 1;
 }
 
 (automake --version) < /dev/null > /dev/null 2>&1 || {
 	echo;
 	echo "You must have automake installed to compile common lib";
 	echo;
-	exit;
+	exit 1;
 }
 
 (autoconf --version) < /dev/null > /dev/null 2>&1 || {
 	echo;
 	echo "You must have autoconf installed to compile common lib";
 	echo;
-	exit;
+	exit 1;
 }
 
 echo "Generating configuration files for common lib, please wait...."
@@ -39,7 +39,7 @@ aclocal -I m4 || exit;
 echo "Running autoheader...."
 autoheader || exit;
 echo "Running automake --add-missing --copy...."
-automake --add-missing --copy;
+automake --add-missing --copy || exit;
 echo "Running autoconf ...."
 autoconf || exit;
 echo "Running automake ...."

--- a/tools/autogen.sh
+++ b/tools/autogen.sh
@@ -6,21 +6,21 @@ echo "Boostrapping StarDict tools..."
 	echo;
 	echo "You must have libtool installed to compile Stardict";
 	echo;
-	exit;
+	exit 1;
 }
 
 (automake --version) < /dev/null > /dev/null 2>&1 || {
 	echo;
 	echo "You must have automake installed to compile Stardict";
 	echo;
-	exit;
+	exit 1;
 }
 
 (autoconf --version) < /dev/null > /dev/null 2>&1 || {
 	echo;
 	echo "You must have autoconf installed to compile Stardict";
 	echo;
-	exit;
+	exit 1;
 }
 
 echo "Generating configuration files for Stardict, please wait...."
@@ -39,7 +39,7 @@ aclocal -I m4 || exit;
 echo "Running autoheader...."
 autoheader || exit;
 echo "Running automake --add-missing --copy...."
-automake --add-missing --copy;
+automake --add-missing --copy || exit;
 echo "Running autoconf ...."
 autoconf || exit;
 echo "Running automake ...."


### PR DESCRIPTION
stardict 3.0.6.2 failed to build on macOS 10.15.7 with this unexpected error:
```
Making all in lib
make[1]: *** No rule to make target `all'.  Stop.
```
Turns out something went wrong in the autogen.sh scripts (I'll file a separate issue for that) and it printed:
```
You must have libtool installed to compile common lib
```
However the autogen.sh scripts don't exit with an error code when that happens, so they continued on and the error message was not initially seen amongst all the other output.

The configure script too printed a message:
```
configure: WARNING: no configuration information is in lib
```
This too was easily missed amongst the other usual configure output.

This PR fixes the autogen.sh scripts so that they exit with an error code when something goes wrong so that their error messages can be seen clearly.