### PR TITLE
autogen.sh: Use glibtoolize if there's no libtoolize

### DIFF
--- a/autogen.sh
+++ b/autogen.sh
@@ -2,7 +2,10 @@
 
 echo "Bootstrapping StarDict root..."
 
-# (libtoolize --version) < /dev/null > /dev/null 2>&1 || {
+# libtoolize=libtoolize
+# command -v "$libtoolize" > /dev/null || libtoolize=glibtoolize
+#
+# ("$libtoolize" --version) < /dev/null > /dev/null 2>&1 || {
 # 	echo;
 # 	echo "You must have libtool installed to compile StarDict";
 # 	echo;
@@ -31,8 +34,8 @@ test -z "$srcdir" && srcdir=.
 topdir=`pwd`
 
 cd "$srcdir"
-# echo "Running libtoolize, please ignore non-fatal messages...."
-# echo n | libtoolize --copy --force || exit;
+# echo "Running $libtoolize, please ignore non-fatal messages...."
+# echo n | "$libtoolize" --copy --force || exit;
 
 echo "Running aclocal...."
 test -d m4 || mkdir m4

--- a/lib/autogen.sh
+++ b/lib/autogen.sh
@@ -2,7 +2,10 @@
 
 echo "Boostrapping common lib..."
 
-(libtoolize --version) < /dev/null > /dev/null 2>&1 || {
+libtoolize=libtoolize
+command -v "$libtoolize" > /dev/null || libtoolize=glibtoolize
+
+("$libtoolize" --version) < /dev/null > /dev/null 2>&1 || {
 	echo;
 	echo "You must have libtool installed to compile common lib";
 	echo;
@@ -31,8 +34,8 @@ test -z "$srcdir" && srcdir=.
 topdir=`pwd`
 
 cd "$srcdir"
-echo "Running libtoolize, please ignore non-fatal messages...."
-echo n | libtoolize --copy --force || exit;
+echo "Running $libtoolize, please ignore non-fatal messages...."
+echo n | "$libtoolize" --copy --force || exit;
 
 echo "Running aclocal...."
 aclocal -I m4 || exit;

--- a/tools/autogen.sh
+++ b/tools/autogen.sh
@@ -2,7 +2,10 @@
 
 echo "Boostrapping StarDict tools..."
 
-(libtoolize --version) < /dev/null > /dev/null 2>&1 || {
+libtoolize=libtoolize
+command -v "$libtoolize" > /dev/null || libtoolize=glibtoolize
+
+("$libtoolize" --version) < /dev/null > /dev/null 2>&1 || {
 	echo;
 	echo "You must have libtool installed to compile Stardict";
 	echo;
@@ -31,8 +34,8 @@ test -z "$srcdir" && srcdir=.
 topdir=`pwd`
 
 cd "$srcdir"
-echo "Running libtoolize, please ignore non-fatal messages...."
-echo n | libtoolize --copy --force || exit;
+echo "Running $libtoolize, please ignore non-fatal messages...."
+echo n | "$libtoolize" --copy --force || exit;
 
 echo "Running aclocal...."
 aclocal -I m4 || exit;


### PR DESCRIPTION
On macOS Apple provides a script called libtool that is unrelated to GNU libtool (and there is no libtoolize). In order to not conflict with Apple's libtool, when GNU libtool is installed on macOS it is customary to install it with a "g" prefix: glibtool and glibtoolize. Update autogen.sh to find glibtoolize if there is no libtoolize.